### PR TITLE
[4/4] transpiler: replace const std::vector& parameters with ArrayRef

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/code_object_utils.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/code_object_utils.cpp
@@ -159,7 +159,7 @@ std::vector<uint8_t> readFile(llvm::StringRef path) {
   return data;
 }
 
-TextSection extractTextSection(const std::vector<uint8_t> &elfData) {
+TextSection extractTextSection(llvm::ArrayRef<uint8_t> elfData) {
   TextSection result;
   auto bufOrErr = llvm::MemoryBuffer::getMemBuffer(
       llvm::StringRef(reinterpret_cast<const char *>(elfData.data()),
@@ -189,7 +189,7 @@ TextSection extractTextSection(const std::vector<uint8_t> &elfData) {
   return result;
 }
 
-std::vector<std::string> listKernelNames(const std::vector<uint8_t> &elfData) {
+std::vector<std::string> listKernelNames(llvm::ArrayRef<uint8_t> elfData) {
   std::vector<std::string> names;
 
   auto bufOrErr = llvm::MemoryBuffer::getMemBuffer(
@@ -272,7 +272,7 @@ std::vector<std::string> listKernelNames(const std::vector<uint8_t> &elfData) {
   return names;
 }
 
-KernelMeta extractKernelMeta(const std::vector<uint8_t> &elfData,
+KernelMeta extractKernelMeta(llvm::ArrayRef<uint8_t> elfData,
                              llvm::StringRef kernelName) {
   KernelMeta meta;
 
@@ -409,7 +409,7 @@ KernelMeta extractKernelMeta(const std::vector<uint8_t> &elfData,
   return meta;
 }
 
-uint64_t findKernelSymbolOffset(const std::vector<uint8_t> &elfData,
+uint64_t findKernelSymbolOffset(llvm::ArrayRef<uint8_t> elfData,
                                 llvm::StringRef kernelName) {
   auto bufOrErr = llvm::MemoryBuffer::getMemBuffer(
       llvm::StringRef(reinterpret_cast<const char *>(elfData.data()),
@@ -456,7 +456,7 @@ uint64_t findKernelSymbolOffset(const std::vector<uint8_t> &elfData,
   return 0;
 }
 
-std::string detectIsaFromElf(const std::vector<uint8_t> &elfData) {
+std::string detectIsaFromElf(llvm::ArrayRef<uint8_t> elfData) {
   // Read the EI_CLASS / e_machine / e_flags fields straight off the
   // ELF64 header rather than building a full ObjectFile — this is
   // called from raise_cli BEFORE we have a CO opened, and we want

--- a/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/code_object_utils.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/code_object_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_HPP
 #define HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_HPP
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <cstdint>
@@ -90,11 +91,11 @@ struct KernelMeta {
 };
 
 std::vector<uint8_t> readFile(llvm::StringRef path);
-TextSection extractTextSection(const std::vector<uint8_t> &elfData);
-std::vector<std::string> listKernelNames(const std::vector<uint8_t> &elfData);
-KernelMeta extractKernelMeta(const std::vector<uint8_t> &elfData,
+TextSection extractTextSection(llvm::ArrayRef<uint8_t> elfData);
+std::vector<std::string> listKernelNames(llvm::ArrayRef<uint8_t> elfData);
+KernelMeta extractKernelMeta(llvm::ArrayRef<uint8_t> elfData,
                              llvm::StringRef kernelName);
-uint64_t findKernelSymbolOffset(const std::vector<uint8_t> &elfData,
+uint64_t findKernelSymbolOffset(llvm::ArrayRef<uint8_t> elfData,
                                 llvm::StringRef kernelName);
 
 // Read the AMDGPU target ISA name (e.g. "gfx1250", "gfx942") encoded in
@@ -105,7 +106,7 @@ uint64_t findKernelSymbolOffset(const std::vector<uint8_t> &elfData,
 // codes), or when the file is not an AMDGPU ELF. Callers that have no
 // other ISA source (e.g. raise_cli when the filename lacks `gfx*`)
 // should treat an empty return as a hard failure rather than guessing.
-std::string detectIsaFromElf(const std::vector<uint8_t> &elfData);
+std::string detectIsaFromElf(llvm::ArrayRef<uint8_t> elfData);
 
 } // namespace transpiler
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/pipeline.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/pipeline.cpp
@@ -208,7 +208,7 @@ bool isStrictMode() {
 // Raise one kernel to IR, compile to a relocatable .o via llc + llvm-mc.
 // On success, writes the .o to objPath and returns true.
 static bool raiseAndCompileKernel(const TextSection &text,
-                                  const std::vector<uint8_t> &codeObjectData,
+                                  llvm::ArrayRef<uint8_t> codeObjectData,
                                   llvm::StringRef kernelName,
                                   llvm::StringRef sourceISA,
                                   llvm::StringRef targetISA,
@@ -347,7 +347,7 @@ void collectTargetPrivateSegmentMetadata(PipelineResult &result,
   }
 }
 
-PipelineResult runPipeline(const std::vector<uint8_t> &codeObjectData,
+PipelineResult runPipeline(llvm::ArrayRef<uint8_t> codeObjectData,
                            llvm::StringRef sourceISA,
                            llvm::StringRef targetISA,
                            llvm::StringRef kernelName,
@@ -396,7 +396,7 @@ PipelineResult runPipeline(const std::vector<uint8_t> &codeObjectData,
   return result;
 }
 
-PipelineResult runPipelineAllKernels(const std::vector<uint8_t> &codeObjectData,
+PipelineResult runPipelineAllKernels(llvm::ArrayRef<uint8_t> codeObjectData,
                                      llvm::StringRef sourceISA,
                                      llvm::StringRef targetISA,
                                      bool enableWritelaneRewrite,

--- a/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/pipeline.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/pipeline.hpp
@@ -1,6 +1,7 @@
 #ifndef HOTSWAP_TRANSPILER_PIPELINE_HPP
 #define HOTSWAP_TRANSPILER_PIPELINE_HPP
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <cstdint>
@@ -80,7 +81,7 @@ struct PipelineResult {
 /// under standard conversions).  Callers repeat the ISA string
 /// instead; the ~5 single-ISA call sites that did this pre-fix are
 /// all updated to the two-string form.
-PipelineResult runPipeline(const std::vector<uint8_t> &codeObjectData,
+PipelineResult runPipeline(llvm::ArrayRef<uint8_t> codeObjectData,
                            llvm::StringRef sourceISA,
                            llvm::StringRef targetISA,
                            llvm::StringRef kernelName,
@@ -91,7 +92,7 @@ PipelineResult runPipeline(const std::vector<uint8_t> &codeObjectData,
 /// HSACO containing every kernel.  Returns success only if every kernel was
 /// raised and compiled. On raise failure, the `fail*` fields carry the
 /// structured `RaiseFailure` details for proof logs and corpus summaries.
-PipelineResult runPipelineAllKernels(const std::vector<uint8_t> &codeObjectData,
+PipelineResult runPipelineAllKernels(llvm::ArrayRef<uint8_t> codeObjectData,
                                      llvm::StringRef sourceISA,
                                      llvm::StringRef targetISA,
                                      bool enableWritelaneRewrite = true,

--- a/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/raiser.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/raiser.cpp
@@ -792,7 +792,7 @@ private:
 // Main raising function
 // ============================================================================
 
-static RaiseResult raiseToIRImpl(const std::vector<uint8_t> &textBytes,
+static RaiseResult raiseToIRImpl(llvm::ArrayRef<uint8_t> textBytes,
                                  llvm::StringRef sourceISA,
                                  llvm::StringRef kernelName,
                                  const KernelMeta &meta,
@@ -2833,7 +2833,7 @@ static RaiseResult raiseToIRImpl(const std::vector<uint8_t> &textBytes,
   return result;
 }
 
-RaiseResult raiseToIR(const std::vector<uint8_t> &textBytes,
+RaiseResult raiseToIR(llvm::ArrayRef<uint8_t> textBytes,
                       llvm::StringRef sourceISA,
                       llvm::StringRef kernelName,
                       const KernelMeta &meta,

--- a/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/raiser.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hotswap/transpiler/raiser.hpp
@@ -4,6 +4,7 @@
 #include "code_object_utils.hpp"
 #include "raise_failure.hpp"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <memory>
@@ -98,7 +99,7 @@ struct RaiseResult {
 // fixtures that pin MODREP-shape IR invariants) rely on. If a
 // future need for a global toggle arises, add a proper
 // `PipelineConfig` field.
-RaiseResult raiseToIR(const std::vector<uint8_t> &textBytes,
+RaiseResult raiseToIR(llvm::ArrayRef<uint8_t> textBytes,
                       llvm::StringRef sourceISA,
                       llvm::StringRef kernelName,
                       const KernelMeta &meta,


### PR DESCRIPTION
transpiler: replace const std::vector& parameters with ArrayRef

